### PR TITLE
Sync main repo to fork and update PR

### DIFF
--- a/.github/workflows/sync-to-raycast.yml
+++ b/.github/workflows/sync-to-raycast.yml
@@ -135,21 +135,35 @@ jobs:
             echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
             sudo apt-get update && sudo apt-get install gh -y
           fi
-          set +e
-          PR_NUM=$(gh pr list \
-            --repo "${UPSTREAM_OWNER}/${UPSTREAM_REPO}" \
-            --head "${FORK_OWNER}:${TARGET_BRANCH}" \
-            --state open \
-            --json number \
-            --jq '.[0].number')
-          set -e
-          if [ -z "$PR_NUM" ]; then
+          # Detect existing PR via REST to avoid false negatives with --head
+          PR_NUM=$(gh api -X GET repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/pulls \
+            -f head="${FORK_OWNER}:${TARGET_BRANCH}" \
+            -f state=open \
+            --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$PR_NUM" ]; then
+            echo "PR already open: #$PR_NUM"
+          else
+            # Create PR; if it races and already exists, treat as success
+            set +e
             gh pr create \
               --repo "${UPSTREAM_OWNER}/${UPSTREAM_REPO}" \
               --head "${FORK_OWNER}:${TARGET_BRANCH}" \
               --base main \
               --title "Add/Update: llm-with-search" \
               --body "Automated sync from ${GITHUB_REPOSITORY}."
-          else
-            echo "PR already open: #$PR_NUM"
+            status=$?
+            set -e
+            if [ $status -ne 0 ]; then
+              # Retry detection; if now present, consider success
+              PR_NUM=$(gh api -X GET repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/pulls \
+                -f head="${FORK_OWNER}:${TARGET_BRANCH}" \
+                -f state=open \
+                --jq '.[0].number' 2>/dev/null || true)
+              if [ -n "$PR_NUM" ]; then
+                echo "PR already open: #$PR_NUM"
+              else
+                echo "Failed to create PR and none found." >&2
+                exit 1
+              fi
+            fi
           fi

--- a/.github/workflows/sync-to-raycast.yml
+++ b/.github/workflows/sync-to-raycast.yml
@@ -9,8 +9,6 @@ on:
 env:
   # Required: create a classic PAT with 'public_repo' (or 'repo') scope and repo RW on your fork.
   # Save it as repository secret RAYCAST_FORK_PAT
-  FORK_OWNER: ${{ vars.RAYCAST_FORK_OWNER || github.repository_owner }}
-  FORK_REPO: ${{ vars.RAYCAST_FORK_REPO || 'raycast-extensions' }}
   UPSTREAM_OWNER: raycast
   UPSTREAM_REPO: extensions
   EXTENSION_DIR: extensions/llm-with-search
@@ -28,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Preflight config check
         run: |
@@ -36,10 +35,43 @@ jobs:
             echo "Missing secret RAYCAST_FORK_PAT" >&2
             exit 1
           fi
-          if [ -z "${FORK_REPO}" ]; then
-            echo "Missing Actions variable RAYCAST_FORK_REPO (your fork repo name, e.g., raycast-extensions or extensions)" >&2
-            exit 1
+
+      - name: Resolve fork coordinates (owner/repo)
+        env:
+          GH_TOKEN: ${{ secrets.RAYCAST_FORK_PAT }}
+        run: |
+          set -e
+          # Ensure gh is available
+          if ! command -v gh >/dev/null 2>&1; then
+            type -p curl >/dev/null || { sudo apt-get update && sudo apt-get install -y curl; }
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt-get update && sudo apt-get install gh -y
           fi
+
+          # Prefer repo variables if provided, otherwise infer from PAT and common fork names
+          FORK_OWNER="${{ vars.RAYCAST_FORK_OWNER }}"
+          FORK_REPO="${{ vars.RAYCAST_FORK_REPO }}"
+
+          if [ -z "$FORK_OWNER" ]; then
+            FORK_OWNER="$(gh api user -q .login)"
+          fi
+
+          if [ -z "$FORK_REPO" ]; then
+            if gh repo view "$FORK_OWNER/extensions" >/dev/null 2>&1; then
+              FORK_REPO="extensions"
+            elif gh repo view "$FORK_OWNER/raycast-extensions" >/dev/null 2>&1; then
+              FORK_REPO="raycast-extensions"
+            else
+              echo "Could not determine fork repo. Set repository variable RAYCAST_FORK_REPO (e.g., 'extensions' or 'raycast-extensions')." >&2
+              exit 1
+            fi
+          fi
+
+          echo "Using fork: $FORK_OWNER/$FORK_REPO"
+          echo "FORK_OWNER=$FORK_OWNER" >> $GITHUB_ENV
+          echo "FORK_REPO=$FORK_REPO" >> $GITHUB_ENV
 
       - name: Configure git
         run: |
@@ -61,7 +93,7 @@ jobs:
           # Start branch from upstream/main with sparse working tree
           git checkout -B "${TARGET_BRANCH}" FETCH_HEAD
           # Add fork as origin for pushing later using PAT as password (fine-grained compatible)
-          git remote add origin https://$FORK_OWNER:${{ secrets.RAYCAST_FORK_PAT }}@github.com/${{ env.FORK_OWNER }}/${{ env.FORK_REPO }}.git
+          git remote add origin https://$FORK_OWNER:${{ secrets.RAYCAST_FORK_PAT }}@github.com/$FORK_OWNER/$FORK_REPO.git
 
       - name: Sync files into fork subdirectory
         run: |


### PR DESCRIPTION
Make the sync-to-raycast workflow more robust by auto-detecting fork details and fixing credential conflicts.

The workflow previously failed due to manual configuration of fork owner/repo or conflicts between the default `GITHUB_TOKEN` and the `RAYCAST_FORK_PAT` when pushing to the fork. This PR introduces logic to automatically resolve the fork owner and repo, and ensures only the provided PAT is used for push operations, preventing credential collision issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-56df0592-a8ac-42bb-b1dc-bcbeb55fa8f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56df0592-a8ac-42bb-b1dc-bcbeb55fa8f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

